### PR TITLE
Remove compiler flag overrides

### DIFF
--- a/docker/scripts/build_larcontent.sh
+++ b/docker/scripts/build_larcontent.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e # script must exit if an error occurs
 
-source /pandora/set_compiler_flags.sh
-
 # Build project
 mkdir build
 cd build


### PR DESCRIPTION
Removes the compiler flag setting script from the LArContent build to avoid overriding the YAML settings from Travis.